### PR TITLE
Added description field to post_playlist method

### DIFF
--- a/soundcloud/soundcloud.py
+++ b/soundcloud/soundcloud.py
@@ -249,12 +249,23 @@ class SoundCloud:
         return PlaylistRequest(self, playlist_id=playlist_id)
 
     def post_playlist(
-        self, sharing: Literal["private", "public"], title: str, tracks: List[int], description: str = ""
+        self,
+        sharing: Literal["private", "public"],
+        title: str,
+        tracks: List[int],
+        description: str = "",
     ) -> Optional[BasicAlbumPlaylist]:
         """
         Create a new playlist
         """
-        body = {"playlist": {"sharing": sharing, "title": title, "tracks": tracks, "description": description}}
+        body = {
+            "playlist": {
+                "sharing": sharing,
+                "title": title,
+                "tracks": tracks,
+                "description": description,
+            }
+        }
         return PostPlaylistRequest(self, body=body)
 
     def delete_playlist(self, playlist_id: int) -> Optional[NoContentResponse]:

--- a/soundcloud/soundcloud.py
+++ b/soundcloud/soundcloud.py
@@ -249,12 +249,12 @@ class SoundCloud:
         return PlaylistRequest(self, playlist_id=playlist_id)
 
     def post_playlist(
-        self, sharing: Literal["private", "public"], title: str, tracks: List[int]
+        self, sharing: Literal["private", "public"], title: str, tracks: List[int], description: str = ""
     ) -> Optional[BasicAlbumPlaylist]:
         """
         Create a new playlist
         """
-        body = {"playlist": {"sharing": sharing, "title": title, "tracks": tracks}}
+        body = {"playlist": {"sharing": sharing, "title": title, "tracks": tracks, "description": description}}
         return PostPlaylistRequest(self, body=body)
 
     def delete_playlist(self, playlist_id: int) -> Optional[NoContentResponse]:

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -31,10 +31,11 @@ def test_playlist_reposters(client: SoundCloud):
 
 def test_post_and_delete_playlist(client: SoundCloud):
     # POST
-    playlist = client.post_playlist("private", "Playlist Test", [1032303631])
+    playlist = client.post_playlist("private", "Playlist Test", [1032303631], "Playlist Description")
     assert (
         isinstance(playlist, BasicAlbumPlaylist)
         and playlist.title == "Playlist Test"
+        and playlist.description == "Playlist Description"
         and playlist.tracks[0].id == 1032303631
     )
 

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -31,7 +31,9 @@ def test_playlist_reposters(client: SoundCloud):
 
 def test_post_and_delete_playlist(client: SoundCloud):
     # POST
-    playlist = client.post_playlist("private", "Playlist Test", [1032303631], "Playlist Description")
+    playlist = client.post_playlist(
+        "private", "Playlist Test", [1032303631], "Playlist Description"
+    )
     assert (
         isinstance(playlist, BasicAlbumPlaylist)
         and playlist.title == "Playlist Test"


### PR DESCRIPTION
I’m not sure if we should add this change as-is, since the POST request for playlists only includes four body fields (see [soundcloud documentation](https://developers.soundcloud.com/docs/api/explorer/open-api#/playlists/post_playlists))

Converting the method parameter to an object would introduce a breaking change.
	