### PR TITLE
Add publisher_metadata to BaseTrack

### DIFF
--- a/soundcloud/resource/track.py
+++ b/soundcloud/resource/track.py
@@ -39,9 +39,10 @@ class Media(BaseData):
 class PublisherMetadata(BaseData):
     """Publisher info"""
 
-    id: str
+    id: int
     urn: str
-    contains_music: bool
+    artist: str
+    contains_music: Optional[bool]
 
 
 @dataclass
@@ -67,6 +68,7 @@ class BaseTrack(BaseItem):
     track_authorization: str
     monetization_model: str
     policy: str
+    publisher_metadata: Optional[PublisherMetadata]
 
 
 @dataclass

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -76,6 +76,17 @@ def test_track_tags(client: SoundCloud):
     assert "Wan Bushi" in tags and "Electronic" in tags
 
 
+def test_publisher_metadata(client: SoundCloud):
+    track = client.get_track(1438987933)
+    assert track
+    publisher_metadata = track.publisher_metadata
+    assert publisher_metadata is not None
+    assert publisher_metadata.artist == "windowseeker"
+    assert publisher_metadata.contains_music is True
+    assert publisher_metadata.id == 1438987933
+    assert publisher_metadata.urn == "soundcloud:tracks:1438987933"
+
+
 def test_track_original_download(client: SoundCloud):
     download = client.get_track_original_download(1032303631)
     assert download


### PR DESCRIPTION
Adds `publisher_metadata` to `BaseTrack`. The newly added `artist` field in `publisher_metadata` warrants the addition to `BaseTrack` in my opinion. Thanks for your great work!