### PR TITLE
fix: User created_at may not be present in response

### DIFF
--- a/soundcloud/resource/user.py
+++ b/soundcloud/resource/user.py
@@ -55,7 +55,7 @@ class User(BasicUser):
     """User with full information"""
 
     comments_count: int
-    created_at: datetime.datetime
+    created_at: Optional[datetime.datetime]
     creator_subscriptions: Tuple[CreatorSubscription, ...]
     creator_subscription: CreatorSubscription
     description: Optional[str]


### PR DESCRIPTION
Since the last time I used this package (probably ~20-30 days), the `created_at` for a user from the SC api is sometimes not present. This actually throws an error due to `dacite` parsing. This change fixes that.